### PR TITLE
Respond to code review: input guards, exec:exec, headless TestGLManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ buildNumber.properties
 
 hs_err_*.log
 
+.DS_Store
+
 # Eclipse m2e generated files
 # Eclipse Core
 .project

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Port of [Abbaye Des Morts GPL version](https://github.com/nevat/abbayedesmorts-g
 
 ## Requirements
 
-* Java 17+
+* Java 21+
 
 * Maven
 
@@ -22,10 +22,10 @@ java -XstartOnFirstThread -jar target/abbayedesmorts-1.0.0-SNAPSHOT.jar
 
 or
 ```
-mvn exec:java
+mvn compile exec:exec
 ```
 
-The -XstartOnFirstThread flag is only required on Mac
+The -XstartOnFirstThread flag is only required on Mac (the `exec:exec` target adds it automatically on macOS)
 
 ## CREDITS
 

--- a/_context/wiki/index.md
+++ b/_context/wiki/index.md
@@ -14,7 +14,7 @@ Read this first, then follow only the links relevant to your current task.
 
 - **Project**: Java/LWJGL3 port of the GPL game *Abbaye Des Morts* (originally C)
 - **Status**: Mid-stage work-in-progress — collision detection and player control done; enemies and animation in progress
-- **Language**: Java 17, Maven build
+- **Language**: Java 21, Maven build
 - **Key pattern**: Loose Entity-Component System (ECS)
 - **Formatting**: Google Java Format via Spotless (`mvn spotless:apply`)
 - **Tests**: JUnit 5 + Mockito; game/collision tests run headless

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -6,7 +6,7 @@
   - Apply before committing: `mvn spotless:apply`
   - Full clean build: `mvn clean spotless:apply package`
   - Spotless runs automatically at compile phase (`mvn compile` will fail if unformatted)
-- **Java version**: 17 (use records, sealed classes, pattern matching where appropriate)
+- **Java version**: 21 (use records, sealed classes, pattern matching where appropriate)
 - **License header**: Every Java file must start with `/* Copyright (C) The Authors $YEAR */` — Spotless enforces this
 - **Architecture**: Loose ECS — entities as Java objects with components; pragmatic, not dogmatic
 - **Naming**: Follow Google Java Style (camelCase methods/fields, PascalCase classes, UPPER_SNAKE constants)

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -26,7 +26,7 @@ Mid-stage work-in-progress:
 - [x] Cross-platform Maven build (Mac arm64/x86_64, Linux x86_64/arm64 profiles)
 - [x] Build toolchain upgraded to Java 21 / compiler-plugin 3.13.0 / JaCoCo 0.8.12
 - [x] Test coverage expanded: `BoundingBox2`, `Vector2`, `Config` (54 new tests)
-- [x] `mvn compile exec:java` target — uses `exec:exec` so `-XstartOnFirstThread` is a real JVM flag (not a program arg) on macOS profiles
+- [x] `mvn compile exec:exec` run target — spawns a fresh `java` process so `-XstartOnFirstThread` is a real JVM flag (not a program arg) on macOS profiles; note `exec:java` no longer works (no `mainClass` configured)
 - [x] `TILE_*` constants migrated to `TileAtlas` (public, canonical); removed from `Stage`
 - [x] `TILES_PER_ROW` / `TILES_PER_COL` moved to `TileAtlas`; circular `Stage` ↔ `TileAtlas` import eliminated
 - [x] `Stage` no longer imports GLFW (dead import removed; model invariant now enforced)
@@ -43,7 +43,7 @@ Mid-stage work-in-progress:
 | Concern | Technology |
 |---------|-----------|
 | Language | Java 21 |
-| Build | Maven (cross-platform profiles); requires `JAVA_HOME=/opt/jdk-21.0.2+13` on this machine; run game with `mvn compile exec:java` |
+| Build | Maven (cross-platform profiles); requires a Java 21 JDK — set `JAVA_HOME` to the local install, whose location is OS- and installation-specific (currently `/Library/Java/JavaVirtualMachines/java21/Contents/Home` on this machine); run game with `mvn compile exec:exec` |
 | Windowing / OpenGL | LWJGL3 3.3.6 (GLFW, OpenGL, OpenAL, STB, Assimp) |
 | Audio | OpenAL via LWJGL3 |
 | Data (maps/config) | Jackson 2.18 (JSON), plain-text map files |
@@ -131,6 +131,7 @@ These are **not regressions**; they are intentionally deferred until crouching i
 
 - ~~`TestRooms.testRoomSwitchRightLeft` and `testRoomNoSwitchLeft` fail with a room-coordinate mismatch~~ — **resolved**: both tests pass as of the `bob_initial_refactor` branch.
 - `Player.checkStaticObject()` line `Stage.toTileX(pos.x()) > 160` compares a tile index (0–31) against 160 — always false. Original C compared pixel coordinates. Marked `// FIXME`; correct tile-column threshold TBD.
+- ~~`TestGLManager.testMatrices()` was not truly headless: it called `AbbayeMain.glStaticInit()` → `glfwInit()`, which needs macOS window-server access, so in a GUI-less environment (CI, sandboxed shell) the suite would *hang* in `[NSApplication run]` rather than fail~~ — **resolved**: the `glStaticInit()`/`setHeadless()` calls were dead weight (the test only exercises pure matrix math) and have been removed; the whole suite is now genuinely headless. Beware reintroducing `glfwInit()` in tests.
 
 ## Key Stakeholders / Users
 

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -26,10 +26,14 @@ Mid-stage work-in-progress:
 - [x] Cross-platform Maven build (Mac arm64/x86_64, Linux x86_64/arm64 profiles)
 - [x] Build toolchain upgraded to Java 21 / compiler-plugin 3.13.0 / JaCoCo 0.8.12
 - [x] Test coverage expanded: `BoundingBox2`, `Vector2`, `Config` (54 new tests)
-- [x] `mvn exec:java` target added (`exec-maven-plugin` 3.4.1; `-XstartOnFirstThread` wired for macOS profiles)
+- [x] `mvn compile exec:java` target — uses `exec:exec` so `-XstartOnFirstThread` is a real JVM flag (not a program arg) on macOS profiles
 - [x] `TILE_*` constants migrated to `TileAtlas` (public, canonical); removed from `Stage`
+- [x] `TILES_PER_ROW` / `TILES_PER_COL` moved to `TileAtlas`; circular `Stage` ↔ `TileAtlas` import eliminated
+- [x] `Stage` no longer imports GLFW (dead import removed; model invariant now enforced)
 - [x] `EnemyType` enum introduced; `Enemy` wired to it via `Enemy.of(EnemyType)` factory
 - [x] `Player.getCollisions()` removed; replaced with typed `isCollidingUp/Down/Left/Right()` accessors
+- [x] `InputHandler` TAB/SPACE guarded by `gameDialog.isActive()` — no longer fires mid-game; `DEBUG_DUMP` now reachable
+- [x] `Stage.clearTilesWhere()` bounds-checked to match `clearTile()` (consistent, no AIOOBE on bad screen index)
 - [ ] Enemy behaviour (concrete `EnemyType` values, parsing from `enemies.txt`)
 - [ ] Animation system
 - [ ] Full game completion / polish
@@ -86,6 +90,7 @@ InputHandler          ← sole owner of GLFWKeyCallbackI; lives in abbaye packag
 - `GLManager.initAll()` **must be called after** `GL.createCapabilities()` in `AbbayeMain.glInit()`. Never call it from a static initialiser.
 - All game-logic tests **must run headless** (no OpenGL/GLFW context). Follow `TestPlayerCollision`, `TestPlayerInput` patterns.
 - All tile-type integer constants (`TILE_*`) live in `TileAtlas` (public). `Stage` imports them via `import static abbaye.model.TileAtlas.*`. Do not re-declare them elsewhere.
+- Texture atlas grid dimensions (`TILES_PER_ROW`, `TILES_PER_COL`) also live in `TileAtlas`. `Stage` does **not** declare them; `TileAtlas` does **not** import `Stage`.
 - `Player` exposes collision state via `isCollidingUp/Down/Left/Right()` boolean accessors. The raw `int[] collision` array is internal; `getCollisions()` has been removed.
 
 ### Key Resources
@@ -125,6 +130,7 @@ These are **not regressions**; they are intentionally deferred until crouching i
 ## Known Pre-existing Issues
 
 - ~~`TestRooms.testRoomSwitchRightLeft` and `testRoomNoSwitchLeft` fail with a room-coordinate mismatch~~ — **resolved**: both tests pass as of the `bob_initial_refactor` branch.
+- `Player.checkStaticObject()` line `Stage.toTileX(pos.x()) > 160` compares a tile index (0–31) against 160 — always false. Original C compared pixel coordinates. Marked `// FIXME`; correct tile-column threshold TBD.
 
 ## Key Stakeholders / Users
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,17 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.4.1</version>
         <configuration>
-          <mainClass>abbaye.AbbayeMain</mainClass>
-          <commandlineArgs>${game.jvm.args}</commandlineArgs>
+          <executable>java</executable>
+          <commandlineArgs>${game.jvm.args} -cp %classpath abbaye.AbbayeMain</commandlineArgs>
         </configuration>
+        <executions>
+          <execution>
+            <id>run-game</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/abbaye/InputHandler.java
+++ b/src/main/java/abbaye/InputHandler.java
@@ -37,8 +37,10 @@ public final class InputHandler {
         return;
       }
 
-      // Dialog controls (TAB / SPACE advance the intro splash)
-      if ((key == GLFW_KEY_TAB || key == GLFW_KEY_SPACE) && action == GLFW_RELEASE) {
+      // Dialog controls (TAB / SPACE advance the intro splash — only when dialog is active)
+      if ((key == GLFW_KEY_TAB || key == GLFW_KEY_SPACE)
+          && action == GLFW_RELEASE
+          && gameDialog.isActive()) {
         gameDialog.startTurn();
         return;
       }

--- a/src/main/java/abbaye/model/Player.java
+++ b/src/main/java/abbaye/model/Player.java
@@ -635,6 +635,8 @@ public final class Player implements Actor {
     if (room == ROOM_ASHES.index()) {
       if ((isBetweenExclusive(tileAt(stagedata, baseTileY + 1, baseTileX), 400, 405))
           || (isBetweenExclusive(tileAt(stagedata, baseTileY + 1, baseTileX + 1), 400, 405))) {
+        // FIXME: compares a tile index (0-31) against 160 — always false.
+        // Original C compared pixel coordinates; needs a correct tile-column threshold.
         if (Stage.toTileX(pos.x()) > 160) {
           stage.clearTile(room, 7, 23);
           stage.clearTile(room, 7, 24);

--- a/src/main/java/abbaye/model/Stage.java
+++ b/src/main/java/abbaye/model/Stage.java
@@ -2,7 +2,6 @@
 package abbaye.model;
 
 import static abbaye.model.TileAtlas.*;
-import static org.lwjgl.glfw.GLFW.*;
 
 import abbaye.AbbayeMain;
 import abbaye.basic.Corners;
@@ -19,9 +18,6 @@ public final class Stage implements Renderable {
   public static final int NUM_SCREENS = SCREENS_X * SCREENS_Y;
   public static final int NUM_COLUMNS = 32;
   public static final int NUM_ROWS = 22;
-
-  public static final int TILES_PER_ROW = 125;
-  public static final int TILES_PER_COL = 30;
 
   public static final int LEFT_EDGE = 0;
   public static final int TOP_EDGE = 0;
@@ -126,6 +122,9 @@ public final class Stage implements Renderable {
    * @param predicate test applied to the current tile-type value; matching tiles are cleared
    */
   public void clearTilesWhere(int screen, IntPredicate predicate) {
+    if (screen < 0 || screen >= NUM_SCREENS) {
+      return;
+    }
     var screenData = stagedata[screen];
     for (int row = 0; row < NUM_ROWS; row++) {
       for (int col = 0; col < NUM_COLUMNS; col++) {

--- a/src/main/java/abbaye/model/TileAtlas.java
+++ b/src/main/java/abbaye/model/TileAtlas.java
@@ -1,8 +1,6 @@
 /* Copyright (C) The Authors 2025-2026 */
 package abbaye.model;
 
-import static abbaye.model.Stage.*;
-
 import abbaye.basic.Corners;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +12,11 @@ import java.util.Map;
  * <p>Results are cached by tile-type ID; the cache is populated on first lookup.
  */
 public final class TileAtlas {
+
+  // ── Texture atlas grid dimensions ──────────────────────────────────────────
+  // Tile sheet is 125 tiles wide × 30 tiles tall (in tile units).
+  public static final int TILES_PER_ROW = 125;
+  public static final int TILES_PER_COL = 30;
 
   // ── Tile-type IDs ──────────────────────────────────────────────────────────
   // Canonical home for all tile-type integer constants. Used for both collision

--- a/src/test/java/abbaye/graphics/TestGLManager.java
+++ b/src/test/java/abbaye/graphics/TestGLManager.java
@@ -1,20 +1,15 @@
-/* Copyright (C) The Authors 2025 */
+/* Copyright (C) The Authors 2025-2026 */
 package abbaye.graphics;
 
 import static abbaye.graphics.GLManager.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import abbaye.AbbayeMain;
-import abbaye.Config;
 import org.junit.jupiter.api.Test;
 
 public class TestGLManager {
 
   @Test
   public void testMatrices() {
-    Config.config().setHeadless(true);
-    AbbayeMain.glStaticInit();
-
     var tileSize = 0.7f;
     var x = 0.6f;
     var y = 0.4f;


### PR DESCRIPTION
## Summary

Follow-up to #29, addressing all findings from the code review (see `code-review-2026-08-06-1233.md`), plus documentation fixes.

### Review responses (89ace99)
- **InputHandler**: TAB/SPACE now guarded by `gameDialog.isActive()` — dialog controls no longer fire mid-game, and the `TAB → DEBUG_DUMP` mapping is reachable
- **pom**: run target switched from `exec:java` to `exec:exec` spawning a fresh `java` process, so `-XstartOnFirstThread` is a real JVM flag on macOS (was silently passed as a program argument)
- **Stage**: `clearTilesWhere()` bounds-checks the screen index to match `clearTile()`; dead GLFW import removed (model-package invariant now holds)
- **TileAtlas**: `TILES_PER_ROW`/`TILES_PER_COL` moved here from `Stage`, eliminating the circular static imports between the two classes
- **Player**: `FIXME` documenting the pre-existing always-false tile-index comparison in `checkStaticObject()` (also recorded in the wiki)

### Additional fixes (6096198)
- **TestGLManager made truly headless**: removed dead `glStaticInit()`/`setHeadless()` calls — the test only exercises pure matrix math, but `glfwInit()` needs window-server access and caused the whole suite to *hang* (not fail) in GUI-less environments such as CI or sandboxed shells
- **Docs**: README/wiki run command corrected to `mvn compile exec:exec`; JDK location documented as OS- and installation-specific; stale Java 17 references bumped to 21

## Test plan
- [x] `mvn test` — 112 tests, 0 failures, 5 skipped (intentionally `@Disabled` pending crouch)
- [x] Verified no test source references `glfwInit`/`glStaticInit`
- [ ] Manual smoke test on macOS: `mvn compile exec:exec` — splash, movement, room switching